### PR TITLE
Update environment.yml

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,7 +2,7 @@ name: pangeo-climpred
 channels:
   - conda-forge
 dependencies:
-  - pangeo-notebook
+  - pangeo-notebook==2020.10.08
   - xarray
   - gcsfs
   - intake


### PR DESCRIPTION
The pangeo binder recently changed to require dask-gateway>=0.8 in the workers. Environments with older pods will fail to start the dask workers. I noticed some failures running this notebook on the pangeo binder.